### PR TITLE
rephrase claim

### DIFF
--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -11,7 +11,7 @@
       <main class="">
         <div id="hero" class="bg-primary">
           <h1 class="main-title">Helvetic Ruby 2023</h1>
-          <p class="lead">A conference for the Swiss Ruby programming language community</p>
+          <p class="lead">A Ruby conference in Switzerland.</p>
           <p class="venue-date"><time>24.11.2023</time> in Bern, Switzerland</p>
         </div>
       </main>


### PR DESCRIPTION
It was mentioned that the phrase 

_"for the Swiss Ruby programmming language community"_

sounded too exclusive.