### PR TITLE
Add digest to production CSS file names

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -5,3 +5,15 @@ mkdir ./public
 
 cp CNAME ./public
 cp -r ./src/2023/* ./public
+
+
+BUILD_SUM=$(md5sum public/styles/styles.css | grep -Eo '^[^ ]+')
+CSS_FILE_NAME="styles.${BUILD_SUM}.css"
+
+if [[ "$OSTYPE" =~ ^darwin ]]; then
+  sed -i '' "s|styles.css|${CSS_FILE_NAME}|" ./public/*.html
+else
+  sed -i "s|styles.css|${CSS_FILE_NAME}|" ./public/*.html
+fi
+
+mv ./public/styles/styles.css ./public/styles/${CSS_FILE_NAME}


### PR DESCRIPTION
The stylesheet file name is now dependent on the contents of the file.

This way browsers can restore the file from cache if the stylesheet has not changed and request the new file if it has.

(See https://github.com/MINASWAN/helvetic-ruby.ch/pull/7#pullrequestreview-1294756102)

@lxxxvi I was thinking of implementing something like this as well. Thanks for providing an existing script.