### PR TITLE
Call for speakers

### DIFF
--- a/src/2023/call-for-speakers/index.html
+++ b/src/2023/call-for-speakers/index.html
@@ -13,6 +13,8 @@
         <nav class="menu top-menu">
           <ul class="wrap">
             <li><a href="../">Helvetic Ruby 2023</a></li>
+            <li><a href="../code-of-conduct">Code of Conduct</a></li>
+            <li>Call for speakers</li>
           </ul>
         </nav>
       </header>

--- a/src/2023/call-for-speakers/index.html
+++ b/src/2023/call-for-speakers/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Guidelines for talk submissions to the Helvetic Ruby conference">
+    <title>Call for speakers | Helvetic Ruby Conference 2023</title>
+    <link rel="stylesheet" href="../styles/styles.css">
+  </head>
+  <body>
+    <div class="cover">
+      <header class="constrain">
+        <nav class="menu top-menu">
+          <ul class="wrap">
+            <li><a href="../">Helvetic Ruby 2023</a></li>
+          </ul>
+        </nav>
+      </header>
+      <main class="constrain region">
+        <div class="stack prose">
+          <h1>Helvetic Ruby 2023 call for speakers</h1>
+
+          <p>
+          Helvetic Ruby 2023 is a Ruby conference which will take place in Bern, Switzerland on 24th November 2023. We are looking for speakers!
+          </p>
+
+          <p>
+            The call for speakers is open until <strong><date>31st March 2023</date></strong>.
+          </p>
+
+          <p>All accepted speakers must comply with our <a href="../code-of-conduct">code of conduct</a>.</p>
+
+          <p>
+            We aim for a speaker line-up representing the diversity
+            within the Ruby community. We welcome speakers from different
+            backgrounds, with varied experiences and career paths.
+          </p>
+
+          <h2>Talk format</h2>
+
+          <ul>
+            <li>The planned talk duration is 20-25 minutes.</li>
+            <li>Talks must be given in English.</li>
+          </ul>
+
+          <h2>Presentation topics and audience</h2>
+
+          <p>
+            We are looking for both technical and non-technical talks relevant
+            to the Ruby community. Assume a mix of skill levels and a variety
+            of interests in the audience.
+          </p>
+
+          <h3>Example topics</h3>
+
+          <p>
+            These are just ideas to illustrate possible talk categories. Do not limit yourself.
+          </p>
+
+          <ul>
+            <li>A debugging story</li>
+            <li>Building a better team culture</li>
+            <li>A performance optimization story</li>
+            <li>Mental health</li>
+            <li>A refactoring story</li>
+            <li>Your experience progressing to the next stage of your career, whether as a career changer, an entry-level, mid-level or experienced developer</li>
+            <li>Hiring and interview practices</li>
+            <li>A deep dive into a library or framework</li>
+            <li>Coaching and mentorship</li>
+            <li>Technical and non-technical reasons for the success of your product or service</li>
+          </ul>
+
+          <h2>Speaker benefits</h2>
+
+          <p>Accepted speakers will get free admission to the conference.</p>
+
+          <p>We offer help with talk preparation. Don't hesitate to submit even if this is your first talk!</p>
+
+          <h2>Submit a talk proposal</h2>
+
+          <p>
+            Please fill in our <a href="https://docs.google.com/forms/d/e/1FAIpQLSeKe4NezbwFI0-ps5HjfQUU18IBrOt5Jz7zXfRZ0SehWI9FYA/viewform">call for proposals form</a>.
+          </p>
+
+        </div>
+      </main>
+      <footer>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/src/2023/code-of-conduct/index.html
+++ b/src/2023/code-of-conduct/index.html
@@ -14,6 +14,7 @@
           <ul class="wrap">
             <li><a href="../">Helvetic Ruby 2023</a></li>
             <li>Code of Conduct</li>
+            <li><a href="../call-for-speakers">Call for speakers</a></li>
           </ul>
         </nav>
       </header>

--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -26,6 +26,7 @@
           <nav class="menu">
             <ul class="wrap">
               <li><a href="code-of-conduct">Code of Conduct</a></li>
+              <li><a href="call-for-speakers">Call for speakers</a></li>
               <li><a href="mailto: info@helvetic-ruby.ch">Contact us</a></li>
             </ul>
           </nav>

--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -9,16 +9,23 @@
   </head>
   <body>
     <div class="cover">
-      <main class="">
-        <div class="hero">
-          <h1 class="main-title">Helvetic Ruby 2023</h1>
-          <p class="lead">A Ruby conference in Switzerland.</p>
-          <p class="venue-date"><time>24.11.2023</time> in Bern, Switzerland</p>
+      <main>
+        <div class="hero-wrapper">
+          <div class="hero relative constrain">
+            <h1 class="main-title">Helvetic Ruby 2023</h1>
+            <p class="lead">A Ruby conference in Switzerland.</p>
+            <p class="venue-date"><time>24.11.2023</time> in Bern, Switzerland</p>
 
-          <a href="mailto: keep-me-posted@helvetic-ruby.ch?subject=Keep%20me%20posted&body=[You%20can%20leave%20this%20part%20of%20the%20mail]" class="small shy-white-link my-3">
-            Drop us your <em>email address</em> and you'll always be the first to receive the latest news!
-          </a>
+            <a href="mailto: keep-me-posted@helvetic-ruby.ch?subject=Keep%20me%20posted&body=[You%20can%20leave%20this%20part%20of%20the%20mail]" class="small shy-white-link my-3">
+              Drop us your <em>email address</em> and you'll always be the first to receive the latest news!
+            </a>
 
+            <section class="announcement">
+              <p class="center">
+                <a href="call-for-speakers">Call for speakers now open!</a>
+              </p>
+            </section>
+          </div>
         </div>
       </main>
       <footer class="footer stack constrain">
@@ -59,7 +66,7 @@
 
         <div>
           <p class="small italic">
-            Last updated on <time>12th February 2023</time>.
+            Last updated on <time>14th February 2023</time>.
           </p>
         </div>
       </footer>

--- a/src/2023/styles/styles.css
+++ b/src/2023/styles/styles.css
@@ -213,17 +213,22 @@ a {
 
 /* Main page */
 
-.hero {
+.hero-wrapper {
   color: var(--white);
   background-color: var(--ruby);
+}
+
+.hero {
   display: flex;
   flex-direction: column;
-  height: auto;
-  padding: 1em 2em;
-  min-height: 75vh;
+  padding-top: var(--space-3xl);
+  padding-bottom: var(--space-l-xl);
+  padding-inline: var(--space-m-l);
   justify-content: center;
   align-items: center;
   text-align: center;
+  height: auto;
+  min-height: 75vh;
 }
 
 .venue-date {
@@ -233,6 +238,24 @@ a {
   background-color: var(--white);
   color: var(--ruby);
   font-weight: bold;
+}
+
+.announcement {
+  position: absolute;
+  top: var(--space-s-l);
+  right: var(--space-2xs);
+  background-color: var(--white);
+  color: var(--grey);
+  transform: rotate(-6deg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 7em;
+  height: 7em;
+  line-height: 1.3;
+  padding: var(--space-s-l);
+  border-radius: 100%;
+  border: 2px solid var(--ruby);
 }
 
 .footer {
@@ -277,6 +300,10 @@ a {
 }
 
 /* Utilities */
+
+.relative {
+  position: relative;
+}
 
 .lead {
   font-size: var(--step-2);

--- a/src/2023/styles/styles.css
+++ b/src/2023/styles/styles.css
@@ -130,6 +130,7 @@ ul {
 
 h1 { font-size: var(--step-4); }
 h2 { font-size: var(--step-3); }
+h3 { font-size: var(--step-2); }
 
 .prose li {
   margin-left: 1.5em;


### PR DESCRIPTION
Adds a call for speakers page with guidelines for talk submissions and a link to the talk proposal form.

I added a link to the call for speakers page to the footer and also as a call-to-action in the hero section of the home page:

![image](https://user-images.githubusercontent.com/677998/218817309-9e3f9db7-5db2-4f55-9072-52a8c6ceb4dd.png)
