### PR TITLE
mention that call for speakers has ended

### DIFF
--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -16,12 +16,14 @@
             <p class="lead">A Ruby conference in Switzerland.</p>
             <p class="venue-date"><time>24.11.2023</time> in Bern, Switzerland</p>
 
-            <p class="call-for-speakers-ended">The Call for Speakers has ended on <time>31.03.2023</time>.</p>
-
             <a href="mailto: keep-me-posted@helvetic-ruby.ch?subject=Keep%20me%20posted&body=[You%20can%20leave%20this%20part%20of%20the%20mail]" class="small shy-white-link my-3">
               Drop us your <em>email address</em> and you'll always be the first to receive the latest news!
             </a>
           </div>
+        </div>
+
+        <div class="flash relative">
+          <p class="call-for-speakers-ended">The Call for Speakers has ended on <time>31.03.2023</time>.</p>
         </div>
       </main>
       <footer class="footer stack constrain">

--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -16,6 +16,8 @@
             <p class="lead">A Ruby conference in Switzerland.</p>
             <p class="venue-date"><time>24.11.2023</time> in Bern, Switzerland</p>
 
+            <p class="call-for-speakers-ended">The Call for Speakers has ended on <time>31.03.2023</time>.</p>
+
             <a href="mailto: keep-me-posted@helvetic-ruby.ch?subject=Keep%20me%20posted&body=[You%20can%20leave%20this%20part%20of%20the%20mail]" class="small shy-white-link my-3">
               Drop us your <em>email address</em> and you'll always be the first to receive the latest news!
             </a>

--- a/src/2023/styles/styles.css
+++ b/src/2023/styles/styles.css
@@ -89,6 +89,7 @@ nav {
   --white: #fff;
   --ruby: #cc0000;
   --grey: #101010;
+  --gold: Gold;
 }
 
 /* Typography */
@@ -240,11 +241,15 @@ a {
   font-weight: bold;
 }
 
+.flash {
+  text-align: center;
+}
+
 .call-for-speakers-ended {
-  margin: 1rem;
-  font-size: var(--step--1);
+  padding: 0.6rem;
+  background-color: var(--gold);
+  font-size: var(--step--2);
   color: var(--gray);
-  opacity: 0.8;
 }
 
 .call-for-speakers-ended time {

--- a/src/2023/styles/styles.css
+++ b/src/2023/styles/styles.css
@@ -240,6 +240,17 @@ a {
   font-weight: bold;
 }
 
+.call-for-speakers-ended {
+  margin: 1rem;
+  font-size: var(--step--1);
+  color: var(--gray);
+  opacity: 0.8;
+}
+
+.call-for-speakers-ended time {
+  text-decoration: underline;
+}
+
 .announcement {
   position: absolute;
   top: var(--space-s-l);


### PR DESCRIPTION
![Screenshot 2023-04-19 at 07-50-37 Helvetic Ruby Conference 2023](https://user-images.githubusercontent.com/1409672/232978901-4480cca9-a554-4626-a3ed-3b3c3c68f083.png)
