### PR TITLE
Add SVG favicon

### DIFF
--- a/src/2023/call-for-speakers/index.html
+++ b/src/2023/call-for-speakers/index.html
@@ -7,6 +7,7 @@
     <title>Call for speakers | Helvetic Ruby Conference 2023</title>
     <link rel="stylesheet" href="../styles/styles.css">
     <link href="https://ruby.social/@helvetic_ruby" rel="me">
+    <link rel="icon" href="../images/favicon.svg">
   </head>
   <body>
     <div class="cover">

--- a/src/2023/code-of-conduct/index.html
+++ b/src/2023/code-of-conduct/index.html
@@ -7,6 +7,7 @@
     <title>Code of Conduct | Helvetic Ruby Conference 2023</title>
     <link rel="stylesheet" href="../styles/styles.css">
     <link href="https://ruby.social/@helvetic_ruby" rel="me">
+    <link rel="icon" href="../images/favicon.svg">
   </head>
   <body>
     <div class="cover">

--- a/src/2023/images/favicon.svg
+++ b/src/2023/images/favicon.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 107 168" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M44.333 143.373L45.896 123.764L78.862 159.856L31.829 167.529L44.333 143.373Z" fill="#B90000"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 138.684L2.984 59.537L47.744 86.819L45.896 123.764L44.333 143.373L31.829 167.529L0 138.684Z" fill="#FF1D1D"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M66.113 52.575L47.743 86.819L45.896 123.764L78.862 159.856L106.855 131.011L66.113 52.575Z" fill="#CF0000"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M68.49 14.21L70.763 43.907L66.113 52.575L106.855 131.011V52.575L68.489 14.209L68.49 14.21Z" fill="#FF3232"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2.98401 59.537L44.76 0L68.49 14.21L70.763 43.907L66.113 52.575L47.743 86.819L2.98401 59.537Z" fill="#FF6363"/>
+<path d="M62.203 66.216H44.627V84.426H26.417V102.002H44.627V120.212H62.203V102.002H80.413V84.426H62.203V66.216Z" fill="#F5F5F5"/>
+</svg>

--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -7,6 +7,7 @@
     <title>Helvetic Ruby Conference 2023</title>
     <link rel="stylesheet" href="styles/styles.css">
     <link href="https://ruby.social/@helvetic_ruby" rel="me">
+    <link rel="icon" href="images/favicon.svg">
   </head>
   <body>
     <div>


### PR DESCRIPTION
SVG favicons are not supported by some browsers (currently Safari and some mobile browsers). I see it as an enhancement rather than a must. Reusing the SVG image we already we have is a small step and better than no favicon at all.