### PR TITLE
Add links to talks and ticket page

### DIFF
--- a/src/2023/code-of-conduct/index.html
+++ b/src/2023/code-of-conduct/index.html
@@ -21,6 +21,7 @@
           <ul class="wrap">
             <li><a href="../talks">Talks</a></li>
             <li>Code of Conduct</li>
+            <li><a href="https://ti.to/helvetic-ruby/helvetic-ruby-2023/with/helvetic-ruby-2023-early-bird" class="cta">Buy a ticket</a></li>
           </ul>
         </nav>
       </header>

--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -12,7 +12,14 @@
   <body>
     <div>
       <header class="constrain">
-        <nav class="menu">
+        <nav class="menu top-menu">
+          <ul class="wrap">
+            <li><a href="talks">Talks</a></li>
+            <li><a href="#location">Location</a></li>
+          </ul>
+          <div>
+            <a href="https://ti.to/helvetic-ruby/helvetic-ruby-2023/with/helvetic-ruby-2023-early-bird" class="cta">Buy a ticket</a>
+          </div>
         </nav>
       </header>
 
@@ -57,6 +64,12 @@
           <p class="lead">
             Join us for a day of engaging talks and networking with fellow Ruby enthusiasts. We are planning a single track with plenty of time between talks for meeting community members from accross Switzerland and abroad.
           </p>
+        </section>
+
+        <section>
+          <div class="flex-center">
+            <a href="https://ti.to/helvetic-ruby/helvetic-ruby-2023/with/helvetic-ruby-2023-early-bird" class="cta">Buy a ticket</a>
+          </div>
         </section>
 
         <section class="region stack">
@@ -159,7 +172,7 @@
           </div>
         </section>
 
-        <section class="center">
+        <section class="center" id="location">
           <h2 class="eyebrow">Location</h2>
 
           <div class="venue-location">

--- a/src/2023/talks/index.html
+++ b/src/2023/talks/index.html
@@ -21,6 +21,7 @@
           <ul class="wrap">
             <li>Talks</li>
             <li><a href="../code-of-conduct">Code of Conduct</a></li>
+            <li><a href="https://ti.to/helvetic-ruby/helvetic-ruby-2023/with/helvetic-ruby-2023-early-bird" class="cta">Buy a ticket</a></li>
           </ul>
         </nav>
       </header>


### PR DESCRIPTION
![image](https://github.com/MINASWAN/helvetic-ruby.ch/assets/677998/bf7821e1-0881-47e0-b906-f5cc6f483565)

![image](https://github.com/MINASWAN/helvetic-ruby.ch/assets/677998/c6c58601-9379-4a19-a909-e5d1d3ba5c37)

![image](https://github.com/MINASWAN/helvetic-ruby.ch/assets/677998/ab92e9fb-33b4-453d-aa41-09c96efdcb98)

The talks page doesn't look so good on mobile:

![image](https://github.com/MINASWAN/helvetic-ruby.ch/assets/677998/931a9ace-3a3a-41c0-af92-1f578864395e)
