### PR TITLE
Logo sizes

### DIFF
--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -231,7 +231,7 @@
 
               <div class="sponsor sponsor--bronze">
                 <a href="https://www.on-running.com/" class="logo">
-                  <img src="images/sponsors/on.svg" alt="On logo" />
+                  <img src="images/sponsors/on.svg" alt="On logo" style="max-height: 5rem" />
                 </a>
               </div>
             </div>

--- a/src/2023/styles/styles.css
+++ b/src/2023/styles/styles.css
@@ -437,7 +437,7 @@ a:focus .speaker-picture {
 }
 
 .partner img {
-  max-height: 4rem;
+  max-height: 5rem;
 }
 
 /* Organizers */

--- a/src/2023/styles/styles.css
+++ b/src/2023/styles/styles.css
@@ -428,7 +428,7 @@ a:focus .speaker-picture {
 }
 
 .sponsor--gold img {
-  max-height: 5rem;
+  max-height: 6rem;
 }
 
 .sponsor--bronze img,


### PR DESCRIPTION
The height constraints were made with "horizontal" logos in mind, i.e.
those that are wider than taller. The logos that are taller than wider
need more vertical space to appear proportionate to the rest.

After these adjustments the gold sponsor logos looked a little small as well, so I bumped up their sizes as well.