### PR TITLE
fix bug with mailto

### DIFF
--- a/src/2023/index.html
+++ b/src/2023/index.html
@@ -179,7 +179,7 @@
               Drop us your email address and you'll always be the first to receive the latest news!
             </p>
             <p>
-              <a href="mailto: keep-me-posted@helvetic-ruby.ch?subject=Keep%20me%20posted&body=[You%20can%20leave%20this%20part%20of%20the%20mail]" class="cta">
+              <a href="mailto:keep-me-posted@helvetic-ruby.ch?subject=Keep%20me%20posted&body=[You%20can%20leave%20this%20part%20of%20the%20mail]" class="cta">
                 Join mailing list
               </a>
             </p>


### PR DESCRIPTION
Some browsers would fail to open the mail client if there's a white space after the mailto: keyword in the `href` attribute.