### PR TITLE
Open the 2024 call for speakers

### DIFF
--- a/src/2024/call-for-speakers/index.html
+++ b/src/2024/call-for-speakers/index.html
@@ -19,7 +19,8 @@
             </a>
           </div>
           <ul class="wrap">
-            <li><a href="../code-of-conduct">Code of Conduct</a></li>
+            <li><a href="../location">Location</a></li>
+            <li><a href="../schedule">Schedule</a></li>
             <li>Call for speakers</li>
           </ul>
         </nav>
@@ -29,7 +30,11 @@
           <h1>Helvetic Ruby 2024 call for speakers</h1>
 
           <p>
-            Helvetic Ruby 2024 is a Ruby conference which will take place in Zurich, Switzerland on 17th May 2024.
+            Helvetic Ruby 2024 is a Ruby conference which will take place in Zurich, Switzerland on 17th May 2024. We are looking for speakers!
+          </p>
+
+          <p>
+            The call for speakers is open until <strong><date>25th February 2024</date></strong>.
           </p>
 
           <p>
@@ -45,7 +50,7 @@
           <h2>Talk format</h2>
 
           <ul>
-            <li>The planned talk duration is 20-25 minutes.</li>
+            <li>The planned talk duration is 25-30 minutes.</li>
             <li>Talks must be given in English.</li>
           </ul>
 
@@ -79,12 +84,25 @@
           <h2>Speaker benefits</h2>
 
           <p>Accepted speakers will get free admission to the conference.</p>
+          <p>We also cover travel and accommodation expenses. If your company is able to cover those costs instead, we will gladly list them as a travel sponsor.</p>
 
           <p>We offer help with talk preparation. Don't hesitate to submit even if this is your first talk!</p>
 
+          <h2>Submit a talk proposal</h2>
+
+          <p>
+            Please fill in our <a href="https://forms.gle/pKnK7rSXELzAD5ud9">call for proposals form</a>.
+          </p>
+
         </div>
       </main>
-      <footer>
+      <footer class="footer stack constrain region">
+        <nav class="menu">
+          <ul class="wrap">
+            <li><a href="../code-of-conduct">Code of Conduct</a></li>
+            <li><a href="mailto: info@helvetic-ruby.ch">Contact us</a></li>
+          </ul>
+        </nav>
       </footer>
     </div>
   </body>

--- a/src/2024/index.html
+++ b/src/2024/index.html
@@ -17,6 +17,7 @@
             <li><a href="location">Location</a></li>
             <li><a href="schedule">Schedule</a></li>
             <li><a href="#sponsors">Sponsors</a></li>
+            <li><a href="call-for-speakers">Call for speakers</a></li>
           </ul>
         </nav>
       </header>
@@ -63,6 +64,11 @@
             Helvetic Ruby 2024 is a single-day, single-track conference for Ruby programming language enthusiasts and professionals from Switzerland and abroad.
             We loved meeting the community in Bern in 2023. This year we invite you to a new city and warmer weather.
           </p>
+        </section>
+
+        <section>
+          <h2 class="eyebrow">Call for speakers</h2>
+          <p>Do you want to give a talk at Helvetic Ruby? Learn more and apply on the <a href="call-for-speakers">call for speakers</a> page.</p>
         </section>
 
         <section>
@@ -200,7 +206,7 @@
 
         <div>
           <p class="small italic">
-            Last updated on <time>14th January 2024</time>.
+            Last updated on <time>19th January 2024</time>.
           </p>
         </div>
       </footer>

--- a/src/2024/location/index.html
+++ b/src/2024/location/index.html
@@ -20,6 +20,7 @@
           </div>
           <ul class="wrap">
             <li>Location</li>
+            <li><a href="../call-for-speakers">Call for speakers</a></li>
           </ul>
         </nav>
       </header>

--- a/src/2024/schedule/index.html
+++ b/src/2024/schedule/index.html
@@ -21,6 +21,7 @@
           <ul class="wrap">
             <li><a href="../location">Location</a></li>
             <li>Schedule</li>
+            <li><a href="../call-for-speakers">Call for speakers</a></li>
           </ul>
         </nav>
       </header>


### PR DESCRIPTION
The form will be open until 25th February 2024.

I've clarified that we offer to cover travel and hotel expenses.

I've also bumped up the expected talk duration by 5 minutes based on feedback from 2023.