### PR TITLE
Start ticket sales for 2024

### DIFF
--- a/src/2024/code-of-conduct/index.html
+++ b/src/2024/code-of-conduct/index.html
@@ -19,6 +19,9 @@
             </a>
           </div>
           <ul class="wrap">
+            <li><a href="../location">Location</a></li>
+            <li><a href="../schedule">Schedule</a></li>
+            <li><a href="https://ti.to/helvetic-ruby/helvetic-ruby-2024" class="cta">Buy a ticket</a></li>
           </ul>
         </nav>
       </header>

--- a/src/2024/index.html
+++ b/src/2024/index.html
@@ -19,6 +19,9 @@
             <li><a href="#sponsors">Sponsors</a></li>
             <li><a href="call-for-speakers">Call for speakers</a></li>
           </ul>
+          <div>
+            <a href="https://ti.to/helvetic-ruby/helvetic-ruby-2024/" class="cta">Buy a ticket</a>
+          </div>
         </nav>
       </header>
 
@@ -67,6 +70,12 @@
         </section>
 
         <section>
+          <div class="flex-center">
+            <a href="https://ti.to/helvetic-ruby/helvetic-ruby-2024/" class="cta">Buy a ticket</a>
+          </div>
+        </section>
+
+        <section  class="region">
           <h2 class="eyebrow">Call for speakers</h2>
           <p>Do you want to give a talk at Helvetic Ruby? Learn more and apply on the <a href="call-for-speakers">call for speakers</a> page.</p>
         </section>

--- a/src/2024/location/index.html
+++ b/src/2024/location/index.html
@@ -21,6 +21,7 @@
           <ul class="wrap">
             <li>Location</li>
             <li><a href="../call-for-speakers">Call for speakers</a></li>
+            <li><a href="https://ti.to/helvetic-ruby/helvetic-ruby-2024" class="cta">Buy a ticket</a></li>
           </ul>
         </nav>
       </header>

--- a/src/2024/schedule/index.html
+++ b/src/2024/schedule/index.html
@@ -22,6 +22,7 @@
             <li><a href="../location">Location</a></li>
             <li>Schedule</li>
             <li><a href="../call-for-speakers">Call for speakers</a></li>
+            <li><a href="https://ti.to/helvetic-ruby/helvetic-ruby-2024" class="cta">Buy a ticket</a></li>
           </ul>
         </nav>
       </header>


### PR DESCRIPTION
The link to the event on ti.to remains the same and we can manage ticket variants (early bird, regular, etc.) on the ticketing platform.

<details><summary>Screenshot on desktop</summary>
<p>

![image](https://github.com/MINASWAN/helvetic-ruby.ch/assets/677998/92cfb5dd-f691-4714-840e-3ce27dec9cba)


</p>
</details> 

<details><summary>Screenshot on mobile</summary>
<p>

The menu doesn't look great, but we can tweak that later. It wasn't a big problem last year

![image](https://github.com/MINASWAN/helvetic-ruby.ch/assets/677998/156f149b-bb83-4fb8-945a-09670ccd0937)


</p>
</details> 