### PR TITLE
Lazy load the video iframe

### DIFF
--- a/src/2024/index.html
+++ b/src/2024/index.html
@@ -212,7 +212,7 @@
           </h2>
           <p>Check out the <a href="https://www.youtube.com/playlist?list=PL4jngagx9f7TIyNkSkS15oDrVPCa7LXsT">talk recordings</a> and <a href="https://photos.app.goo.gl/eSGGEP4BbrcFGF1p8">pictures</a> from <a href="../2023">Helvetic Ruby 2023</a>.</p>
           <div class="iframe-container">
-            <iframe max-width="600" max-height="400" src="https://www.youtube.com/embed/9sSNcfxSNQk?si=FpJfkgtkAbyexcRD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <iframe max-width="600" max-height="400" src="https://www.youtube.com/embed/9sSNcfxSNQk?si=FpJfkgtkAbyexcRD" loading="lazy" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
           </div>
         </section>
 


### PR DESCRIPTION
In browser that support the attribute, loading the YouTube assets is delayed until when the iframe is about to scroll into view. This puts the priority on loading the primary content of the page.

With the lazy loading, content from YouTube is still downloaded, although visitors may not watch the video. A solution like Lite YouTube Embed would only load the video when pressing play.

https://github.com/paulirish/lite-youtube-embed