### PR TITLE
Announce extra activities at 2025 edition

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,7 +35,7 @@
 
   <div>
     <p class="small italic">
-      Last updated on <time>19th November 2024</time>.
+      Last updated on <time>5th December 2024</time>.
     </p>
   </div>
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,16 @@
 <header class="constrain">
   <nav class="menu top-menu">
+    {% unless page.no_logo %}
+    <div>
+      <a href="/">
+        <img src="/images/helvetic-ruby.svg" width="138" height="48" alt="Helvetic Ruby" />
+      </a>
+    </div>
+    {% endunless %}
+
     <ul class="wrap">
       <li><a href="/location">Location</a></li>
+      <li><a href="/schedule">Schedule</a></li>
       <li><a href="/#sponsors">Sponsors</a></li>
     </ul>
     <div>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@ layout: page
 title: Helvetic Ruby Conference 2025
 description: A single-day, single-track conference for Ruby enthusiasts and professionals from Switzerland and abroad.
 social_media_title: Helvetic Ruby | 23rd May 2025, Geneva
+no_logo: true
 ---
 <main class="constrain stack stack-xl">
   <section class="region">
@@ -20,19 +21,29 @@ social_media_title: Helvetic Ruby | 23rd May 2025, Geneva
       </div>
       <div class="hero-details">
         <div>
-          <div class="highlight eyebrow bold">
-            When
-          </div>
           <div class="lead">
-            <time>23.05.2025</time>
+            May 22–23, 2025<br>
+            <span class="subtle">Geneva, Switzerland</span>
           </div>
         </div>
-        <div>
-          <div class="highlight eyebrow bold">
-            Where
+
+        <div class="hero-dates">
+          <div>
+            <div class="highlight bold">
+              Community day
+            </div>
+            <div class="hero-date">
+              <time>22.05.2025</time>
+            </div>
           </div>
-          <div class="lead">
-            Geneva, Switzerland
+
+          <div>
+            <div class="highlight bold">
+              Talks
+            </div>
+            <div class="hero-date">
+              <time>23.05.2025</time>
+            </div>
           </div>
         </div>
       </div>
@@ -42,7 +53,7 @@ social_media_title: Helvetic Ruby | 23rd May 2025, Geneva
   <section>
     <h2 class="highlight eyebrow">The Swiss Ruby conference travels to Geneva</h2>
     <p class="lead">
-      Helvetic Ruby 2025 is a single-day, single-track conference for Ruby programming language enthusiasts and professionals from Switzerland and abroad.
+      Helvetic Ruby 2025 is single-track conference for Ruby programming language enthusiasts and professionals from Switzerland and abroad.
       We met in <a href="../2023">Bern in 2023</a> and <a href="../2024">Zurich in 2024</a>. In 2025, we are happy to welcome you in Geneva.
     </p>
   </section>
@@ -64,15 +75,21 @@ social_media_title: Helvetic Ruby | 23rd May 2025, Geneva
       <h3>Ample break time</h3>
       <p>A single conference track with long breaks means you have enough time to meet people between the sessions. Or ask questions to the speaker that just came off stage. Or just rest for a bit. We want you refreshed and eager for the next presentation.</p>
     </div>
-
     <div>
       <h3>Extra activities on surrounding days</h3>
-      <p>While the conference talks are on Friday, 23rd May 2025, we are also planning optional community events on Thursday and Saturday. To give you an idea, in 2024 we organized an open source hack day on Thursday and went hiking on Saturday.</p>
+      <p>While the conference talks are on Friday, 23rd May 2025, we are also planning optional community events on Thursday and Saturday.</p>
     </div>
 
     <div>
-      <h3>Chocolate</h3>
-      <p>So far, there hasn't been a Helvetic Ruby conference without Swiss chocolate.</p>
+      <h3>Community day on Thursday, 22nd May</h3>
+      <p>On Thursday afternoon we will iterate on last year's idea of a community space. Work on open source, experiment with new ideas, or hang out with other attendees. More details to come. <a href="mailto:info@helvetic-ruby.ch">Contact us</a> if you want to propose something.
+      </p>
+    </div>
+
+    <div>
+      <h3>Guided tour of CERN on Saturday, 24th May — limited places</h3>
+      <p>On Saturday, 24th May 2025, we organize a guided tour of CERN, the European Organisation for Nuclear Research. The tour takes place from 9:00 until 12:00. The places are limited so please book the tour only if you're confident you can come. You can book by <a href="https://ti.to/helvetic-ruby/helvetic-ruby-2025">purchasing one of the conference tickets</a> with mention "guided tour of CERN". <a href="https://home.cern/">Read more about CERN</a>
+      </p>
     </div>
   </section>
 

--- a/schedule/index.html
+++ b/schedule/index.html
@@ -15,8 +15,9 @@ social_media_title: Schedule | Helvetic Ruby 2025
     <div class="region stack">
       <h2 id="thursday">Thursday, 22nd May 2025</h2>
 
-      <p>Thursday will be a community day.</p>
-      <p>Program to be announced.</p>
+      <p>Thursday will be a community day. Work on open source, experiment with new ideas, or hang out with other attendees. </p>
+
+      <p>Time and location to be announced.</p>
     </div>
 
     <div class="region stack">
@@ -29,8 +30,16 @@ social_media_title: Schedule | Helvetic Ruby 2025
     <div class="region stack">
       <h2 id="saturday">Saturday, 24th May 2025</h2>
 
-      <p>Join us for some optional activities if you're still in Geneva on Saturday.</p>
-      <p>Program to be announced.</p>
+      <article class="schedule-item">
+        <time class="schedule-time">09:00-12:00</time>
+        <div>
+          <h3 class="schedule-item-title">Guided tour of <a href="https://home.cern/">CERN</a></h3>
+          <p class="schedule-details">
+            <strong>Limited places</strong>. You can reserve your spot when you
+            <a href="https://ti.to/helvetic-ruby/helvetic-ruby-2025">buy a conference ticket</a> that includes the guided tour.
+          </p>
+        </div>
+      </article>
     </div>
   </section>
 </main>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -345,6 +345,18 @@ blockquote {
   margin-top: var(--space-s);
 }
 
+.hero-dates {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-l);
+}
+
+.hero-date {
+  font-size: var(--step-1);
+  line-height: 1.3;
+}
+
 .speakers {
   --space: var(--space-l);
   --minimum: 20ch;


### PR DESCRIPTION
Specific mention of the community day in the header

![image](https://github.com/user-attachments/assets/30313b2b-b9c9-42a8-8928-ee8fb03d1287)


Mention of Thursday and Saturday program in "what to expect"

![image](https://github.com/user-attachments/assets/796af9e7-7fb9-448d-b909-98f135d90fea)


I've added the timing of the visit on the schedule page, since we already know it.

![image](https://github.com/user-attachments/assets/ea2cac12-0ba8-478f-bf75-50f82a0d58d2)
