### PR TITLE
2025 call for speakers

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,6 +12,7 @@
       <li><a href="/location">Location</a></li>
       <li><a href="/schedule">Schedule</a></li>
       <li><a href="/#sponsors">Sponsors</a></li>
+      <li><a href="/call-for-speakers">Call for speakers</a></li>
     </ul>
     <div>
       <a href="https://ti.to/helvetic-ruby/helvetic-ruby-2025" class="cta">Buy a ticket</a>

--- a/call-for-speakers/index.html
+++ b/call-for-speakers/index.html
@@ -9,11 +9,11 @@ social_media_title: Call for speakers | Helvetic Ruby Conference 2025
     <h1>Helvetic Ruby 2025 call for speakers</h1>
 
     <p>
-      Helvetic Ruby 2025 is a Ruby conference which will take place in Geneva, Switzerland on 23rd May 2025.
+      Helvetic Ruby 2025 is a Ruby conference which will take place in Geneva, Switzerland on 23rd May 2025. We are looking for speakers!
     </p>
 
     <p>
-      <strong>The call for speakers is not yet open.</strong> We provide the information below in advance so that you know what to expect.
+      The call for speakers is <strong>open until <date>29th January 2025</date></strong>.
     </p>
 
     <p>
@@ -66,5 +66,11 @@ social_media_title: Call for speakers | Helvetic Ruby Conference 2025
     <p>We also cover travel and accommodation expenses. If your company is able to cover those costs instead, we will gladly list them as a travel sponsor.</p>
 
     <p>We offer help with talk preparation. Don't hesitate to submit even if this is your first talk!</p>
+
+    <h2>Submit a talk proposal</h2>
+
+    <p>
+      Please fill in our <a href="https://forms.gle/chNTdCXRdqK3FoKS6">call for proposals form</a>.
+    </p>
   </div>
 </main>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,12 @@ no_logo: true
   </section>
 
   <section class="region stack stack-s">
-    <h2>What to expect</h2>
+    <h2>Call for speakers</h2>
+    <p>Do you want to give a talk at Helvetic Ruby? Learn more and apply on the <a href="call-for-speakers">call for speakers</a> page.</p>
+  </section>
+
+  <section class="region stack stack-s">
+    <h2>What to expect at Helvetic Ruby</h2>
     <div>
       <h3>A good mix of talks</h3>
       <p>We aim for a varied programme where everyone can learn something, no matter your level of expertise.</p>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -256,8 +256,8 @@ blockquote {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  grid-gap: var(--space-s-m);
-  gap: var(--space-s-m);
+  column-gap: var(--space-s-m);
+  row-gap: var(--space-3xs-2xs);
 }
 
 .region {
@@ -300,7 +300,8 @@ blockquote {
   align-items: center;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: var(--space-s-m);
+  column-gap: var(--space-s-m);
+  row-gap: var(--space-m-l);
 }
 
 /* Main page */


### PR DESCRIPTION
Updates links and information about the call for speakers.

The new menu item causes the header to wrap, but I think it looks okay after a little tweaking for small screens.

![image](https://github.com/user-attachments/assets/ebeb6e51-a49a-4ba8-9225-593b41ef3a6b)

![image](https://github.com/user-attachments/assets/ec2b6fdb-cc31-49fb-9973-c6c1d1334882)
