### PR TITLE
Update social media links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,16 +17,9 @@
           </div>
         </a>
 
-        <a href="https://twitter.com/helvetic_ruby" title="Follow us on Twitter">
+        <a href="https://www.linkedin.com/company/helvetic-ruby" title="Follow us on LinkedIn">
           <div class="social--network-icon">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 248 204" fill="currentColor" stroke="currentColor">
-              <path d="M221.95,51.29c0.15,2.17,0.15,4.34,0.15,6.53c0,66.73-50.8,143.69-143.69,143.69v-0.04
-              C50.97,201.51,24.1,193.65,1,178.83c3.99,0.48,8,0.72,12.02,0.73c22.74,0.02,44.83-7.61,62.72-21.66
-              c-21.61-0.41-40.56-14.5-47.18-35.07c7.57,1.46,15.37,1.16,22.8-0.87C27.8,117.2,10.85,96.5,10.85,72.46c0-0.22,0-0.43,0-0.64
-              c7.02,3.91,14.88,6.08,22.92,6.32C11.58,63.31,4.74,33.79,18.14,10.71c25.64,31.55,63.47,50.73,104.08,52.76
-              c-4.07-17.54,1.49-35.92,14.61-48.25c20.34-19.12,52.33-18.14,71.45,2.19c11.31-2.23,22.15-6.38,32.07-12.26
-              c-3.77,11.69-11.66,21.62-22.2,27.93c10.01-1.18,19.79-3.86,29-7.95C240.37,35.29,231.83,44.14,221.95,51.29z"/>
-            </svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="72" height="72" viewBox="0 0 72 72" fill="currentColor" stroke="currentColor"><g fill="none" fill-rule="evenodd"><path fill="currentColor" d="M8 72h56a8 8 0 0 0 8-8V8a8 8 0 0 0-8-8H8a8 8 0 0 0-8 8v56a8 8 0 0 0 8 8Z"/><path fill="#FFF" d="M62 62H51.316V43.802c0-4.99-1.896-7.777-5.845-7.777-4.296 0-6.54 2.901-6.54 7.777V62H28.632V27.333H38.93v4.67s3.096-5.729 10.453-5.729c7.353 0 12.617 4.49 12.617 13.777V62ZM16.35 22.794c-3.508 0-6.35-2.864-6.35-6.397C10 12.864 12.842 10 16.35 10c3.507 0 6.347 2.864 6.347 6.397 0 3.533-2.84 6.397-6.348 6.397ZM11.032 62h10.736V27.333H11.033V62Z"/></g></svg>
           </div>
         </a>
       </div>
@@ -37,7 +30,7 @@
     <p>Past editions: <a href="/2024">2024</a>, <a href="/2023">2023</a>.</p>
 
     <p class="small italic">
-      Last updated on <time>30th January 2025</time>.
+      Last updated on <time>16th February 2025</time>.
     </p>
   </div>
 </footer>


### PR DESCRIPTION
We've only been posting to ruby.social and LinkedIn.

The LinkedIn logo doesn't fit very well, but I don't want to spend more time on it.

![image](https://github.com/user-attachments/assets/3479f571-aed3-4d58-b89a-9e09ec4653de)
