### PR TITLE
Announce 2026

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,7 +30,7 @@
     <p>Past editions: <a href="/2024">2024</a>, <a href="/2023">2023</a>.</p>
 
     <p class="small italic">
-      Last updated on <time>24th May 2025</time>.
+      Last updated on <time>8th September 2025</time>.
     </p>
   </div>
 </footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
     {% unless page.no_logo %}
     <div>
       <a href="/">
-        <img src="/images/helvetic-ruby.svg" width="138" height="48" alt="Helvetic Ruby" />
+        <img src="/images/helvetic-ruby.svg" width="138" height="48" alt="Helvetic Ruby">
       </a>
     </div>
     {% endunless %}

--- a/index.html
+++ b/index.html
@@ -1,15 +1,15 @@
 ---
 layout: page
-title: Helvetic Ruby Conference 2025
+title: Helvetic Ruby Conference 2026
 description: A single-track conference for Ruby enthusiasts and professionals from Switzerland and abroad.
-social_media_title: Helvetic Ruby | May 22-23, 2025, Geneva
+social_media_title: Helvetic Ruby | November 19 - 20, 2026, Zürich
 no_logo: true
 ---
 <main class="constrain stack stack-xl">
   <section class="region">
     <div class="hero">
       <div class="hero-brand">
-        <h1 class="main-title"><span class="brand">Helvetic<br> Ruby</span><br> <span class="brand-highlight main-title--year">2025</span></h1>
+        <h1 class="main-title"><span class="brand">Helvetic<br> Ruby</span><br> <span class="brand-highlight main-title--year">2026</span></h1>
         <svg class="ruby" viewBox="0 0 107 168" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill-rule="evenodd" clip-rule="evenodd" d="M44.333 143.373L45.896 123.764L78.862 159.856L31.829 167.529L44.333 143.373Z" fill="#B90000"/>
           <path fill-rule="evenodd" clip-rule="evenodd" d="M0 138.684L2.984 59.537L47.744 86.819L45.896 123.764L44.333 143.373L31.829 167.529L0 138.684Z" fill="#FF1D1D"/>
@@ -19,10 +19,12 @@ no_logo: true
           <path d="M62.203 66.216H44.627V84.426H26.417V102.002H44.627V120.212H62.203V102.002H80.413V84.426H62.203V66.216Z" fill="#F5F5F5"/>
         </svg>
       </div>
-      <div class="hero-details">
+
+      <!-- Old version 2025, I kept it for we moved the whole website to 2025 folder -->
+      <!-- <div class="hero-details">
         <div>
           <div class="lead">
-            May 22–23, 2025<br>
+            May 22-23, 2025<br>
             <span class="subtle">Geneva, Switzerland</span>
           </div>
         </div>
@@ -46,15 +48,44 @@ no_logo: true
             </div>
           </div>
         </div>
+      </div> -->
+
+      <div class="hero-details">
+        <div>
+          <div class="lead">
+            November 19 - 20, 2026<br>
+            <span class="subtle">Zürich, Switzerland</span>
+          </div>
+        </div>
+
+        <div class="hero-dates">
+          <div>
+            <div class="highlight bold">
+              Community day
+            </div>
+            <div class="hero-date">
+              <time>19.11.2026</time>
+            </div>
+          </div>
+
+          <div>
+            <div class="highlight bold">
+              Talks
+            </div>
+            <div class="hero-date">
+              <time>20.11.2026</time>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>
 
   <section>
-    <h2 class="highlight eyebrow">The Swiss Ruby conference travels to Geneva</h2>
+    <h2 class="highlight eyebrow">The Swiss Ruby conference travels back to Zürich</h2>
     <p class="lead">
-      Helvetic Ruby 2025 is a single-track conference for Ruby programming language enthusiasts and professionals from Switzerland and abroad.
-      We met in <a href="../2023">Bern in 2023</a> and <a href="../2024">Zurich in 2024</a>. In 2025, we are happy to welcome you in Geneva.
+      Helvetic Ruby 2026 is a single-track conference for Ruby programming language enthusiasts and professionals from Switzerland and abroad.
+      We met in <a href="../2023">Bern in 2023</a>, <a href="../2024">Zürich in 2024</a> and Geneva in 2025. We are happy to welcome you back in Zürich in 2026.
     </p>
   </section>
 
@@ -159,7 +190,7 @@ no_logo: true
       </li>
     </ul>
     <div class="iframe-container">
-      <iframe max-width="560" max-height="315" src="https://www.youtube-nocookie.com/embed/6O0Cz-3pNp0?si=LSQXVTlZYU8sJ2Pf" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+      <iframe max-width="560" max-height="315" src="https://www.youtube-nocookie.com/embed/gFiKZ9misx4?si=3MLEzPO7779LxCDr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
     </div>
   </section>
 
@@ -202,7 +233,7 @@ no_logo: true
 
   <section class="region center stack stack-xl">
     <div class="stack stack-s">
-      <h2 id="sponsors">Sponsors</h2>
+      <h2 id="sponsors">Sponsors 2025</h2>
 
       <div>
         <p>

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@ no_logo: true
       <address>
         Uptown Geneva<br>
         Rue de la Servette 2<br>
-        1201 Geneva<br/>
+        1201 Geneva<br>
         Switzerland
       </address>
     </div>
@@ -215,25 +215,25 @@ no_logo: true
         <div class="sponsors">
           <div class="sponsor sponsor--silver">
             <a href="https://www.rorvswild.com/" class="logo">
-              <img src="images/sponsors/rorvswild.svg" alt="RoRvsWild logo" />
+              <img src="images/sponsors/rorvswild.svg" alt="RoRvsWild logo">
             </a>
           </div>
 
           <div class="sponsor sponsor--silver">
             <a href="https://www.qoqa.ch/" class="logo">
-              <img src="images/sponsors/qoqa.svg" alt="QoQa logo" />
+              <img src="images/sponsors/qoqa.svg" alt="QoQa logo">
             </a>
           </div>
 
           <div class="sponsor sponsor--silver">
             <a href="https://www.endress.com" class="logo">
-              <img src="images/sponsors/E+H.png" alt="Endress+Hauser logo" />
+              <img src="images/sponsors/E+H.png" alt="Endress+Hauser logo">
             </a>
           </div>
 
           <div class="sponsor sponsor--silver">
             <a href="https://www.appsignal.com/" class="logo">
-              <img src="images/sponsors/appsignal.svg" alt="AppSignal logo" style="height: 3rem;" />
+              <img src="images/sponsors/appsignal.svg" alt="AppSignal logo" style="height: 3rem;">
             </a>
           </div>
         </div>
@@ -244,31 +244,31 @@ no_logo: true
         <div class="sponsors">
           <div class="sponsor sponsor--bronze">
             <a href="https://www.puzzle.ch/" class="logo">
-              <img src="images/sponsors/puzzle.svg" alt="Puzzle ITC logo" style="height: 4rem; max-height: 4rem;" />
+              <img src="images/sponsors/puzzle.svg" alt="Puzzle ITC logo" style="height: 4rem; max-height: 4rem;">
             </a>
           </div>
 
           <div class="sponsor sponsor--bronze">
             <a href="https://www.renuo.ch/" class="logo">
-              <img src="images/sponsors/renuo.png" alt="Renuo logo" />
+              <img src="images/sponsors/renuo.png" alt="Renuo logo">
             </a>
           </div>
 
           <div class="sponsor sponsor--bronze">
             <a href="https://pia-planer.ch/" class="logo">
-              <img src="images/sponsors/pia.png" alt="Pia Planer logo" />
+              <img src="images/sponsors/pia.png" alt="Pia Planer logo">
             </a>
           </div>
 
           <div class="sponsor sponsor--bronze">
             <a href="https://deplo.io/" class="logo">
-              <img src="images/sponsors/deploio.svg" alt="Deploio logo" />
+              <img src="images/sponsors/deploio.svg" alt="Deploio logo">
             </a>
           </div>
 
           <div class="sponsor sponsor--bronze">
             <a href="https://deplo.io/" class="logo">
-              <img src="images/sponsors/deploio.svg" alt="Deploio logo" style="height: 5rem; max-height: 5rem;" />
+              <img src="images/sponsors/deploio.svg" alt="Deploio logo" style="height: 5rem; max-height: 5rem;">
             </a>
           </div>
         </div>
@@ -280,37 +280,37 @@ no_logo: true
       <div class="sponsors">
         <div class="sponsor sponsor--travel">
           <a href="https://thoughtbot.com" class="logo">
-            <img src="images/sponsors/thoughtbot.svg" alt="thoughtbot logo" style="max-height: 3rem" />
+            <img src="images/sponsors/thoughtbot.svg" alt="thoughtbot logo" style="max-height: 3rem">
           </a>
         </div>
 
         <div class="sponsor sponsor--travel">
           <a href="https://github.com" class="logo">
-            <img src="images/sponsors/github.png" alt="GitHub logo" style="max-height: 3rem" />
+            <img src="images/sponsors/github.png" alt="GitHub logo" style="max-height: 3rem">
           </a>
         </div>
 
         <div class="sponsor sponsor--travel">
           <a href="https://scan.com" class="logo">
-            <img src="images/sponsors/scan.svg" alt="scan.com logo" style="max-height: 3rem" />
+            <img src="images/sponsors/scan.svg" alt="scan.com logo" style="max-height: 3rem">
           </a>
         </div>
 
         <div class="sponsor sponsor--travel">
           <a href="https://visuality.pl" class="logo">
-            <img src="images/sponsors/visuality.png" alt="visuality.pl logo" style="max-height: 2.5rem" />
+            <img src="images/sponsors/visuality.png" alt="visuality.pl logo" style="max-height: 2.5rem">
           </a>
         </div>
 
         <div class="sponsor sponsor--travel">
           <a href="https://www.aha.io" class="logo">
-            <img src="images/sponsors/aha.svg" alt="Aha! logo" style="max-height: 1.8rem" />
+            <img src="images/sponsors/aha.svg" alt="Aha! logo" style="max-height: 1.8rem">
           </a>
         </div>
 
         <div class="sponsor sponsor--travel">
           <a href="https://dnsimple.com/" class="logo">
-            <img src="images/sponsors/dnsimple.svg" alt="DNSimple logo" style="height: 3rem" />
+            <img src="images/sponsors/dnsimple.svg" alt="DNSimple logo" style="height: 3rem">
           </a>
         </div>
       </div>
@@ -323,37 +323,37 @@ no_logo: true
     <div class="partners">
       <div class="partner">
         <a href="https://friendlyrb.com/" class="logo">
-          <img src="images/sponsors/friendlyrb.png" alt="friendly.rb logo" />
+          <img src="images/sponsors/friendlyrb.png" alt="friendly.rb logo">
         </a>
       </div>
 
       <div class="partner">
         <a href="https://2024.euruko.org/">
-          <img src="images/sponsors/euruko_black.png" alt="Euruko 2024 logo" style="max-height: 3rem" />
+          <img src="images/sponsors/euruko_black.png" alt="Euruko 2024 logo" style="max-height: 3rem">
         </a>
       </div>
 
       <div class="partner">
         <a href="https://balticruby.org/">
-          <img src="images/sponsors/baltic_ruby.jpeg" alt="Baltic Ruby 2024 logo" style="max-height: 5rem" />
+          <img src="images/sponsors/baltic_ruby.jpeg" alt="Baltic Ruby 2024 logo" style="max-height: 5rem">
         </a>
       </div>
 
       <div class="partner">
         <a href="https://www.grusp.org/">
-          <img src="images/sponsors/grusp.svg" alt="GrUSP logo" />
+          <img src="images/sponsors/grusp.svg" alt="GrUSP logo">
         </a>
       </div>
 
       <div class="partner">
         <a href="https://swissdevjobs.ch/">
-          <img src="images/sponsors/swiss-dev-jobs.png" alt="SwissDevJobs logo" />
+          <img src="images/sponsors/swiss-dev-jobs.png" alt="SwissDevJobs logo">
         </a>
       </div>
 
       <div class="partner">
         <a href="https://www.rubycommunityconference.com/">
-          <img src="images/sponsors/ruby_community_conference.png" alt="Ruby Community Conference logo" />
+          <img src="images/sponsors/ruby_community_conference.png" alt="Ruby Community Conference logo">
         </a>
       </div>
     </div>


### PR DESCRIPTION
This PR announces the 2026 edition. The content for index was changed, the 2025 wasn't yet moved to it's own folder. This needs to be done as a follow up. 

<img width="854" height="682" alt="Screenshot 2025-09-08 at 20 44 29" src="https://github.com/user-attachments/assets/441cf6e0-e4ec-4fa0-ad00-df75afde7245" />
<img width="859" height="624" alt="Screenshot 2025-09-08 at 20 44 23" src="https://github.com/user-attachments/assets/9f65c20e-4a67-48ce-b19d-d185492924aa" />
