### PR TITLE
Fix 2025 links

### DIFF
--- a/2025/index.html
+++ b/2025/index.html
@@ -22,7 +22,7 @@ no_logo: true
       <div class="hero-details">
         <div>
           <div class="lead">
-            May 22–23, 2025<br>
+            May 22-23, 2025<br>
             <span class="subtle">Geneva, Switzerland</span>
           </div>
         </div>
@@ -68,7 +68,7 @@ no_logo: true
           </figure>
           <div>
             <div>
-              <a href="/talks#{{ speaker.id }}">{{ speaker.name }}</a>
+              <a href="/2025/talks#{{ speaker.id }}">{{ speaker.name }}</a>
             </div>
             <div class="speaker-preview-details">
               <p>{{ speaker.title }}</p>
@@ -89,7 +89,7 @@ no_logo: true
           </figure>
           <div>
             <div>
-              <a href="/talks#{{ workshop.id }}">
+              <a href="/2025/talks#{{ workshop.id }}">
                 {{ workshop.presenters | map: "name" | join: " & <br>" }}
               </a>
             </div>

--- a/2025/index.html
+++ b/2025/index.html
@@ -3,7 +3,6 @@ layout: page
 title: Helvetic Ruby Conference 2025
 description: A single-track conference for Ruby enthusiasts and professionals from Switzerland and abroad.
 social_media_title: Helvetic Ruby | May 22-23, 2025, Geneva
-no_logo: true
 ---
 <main class="constrain stack stack-xl">
   <section class="region">


### PR DESCRIPTION
The talks link did lead to 2026, no talks yet... Fix them. Also added logo to be able to navigate to home page. 

<img width="1036" height="1412" alt="Screenshot 2026-05-09 at 16 08 25" src="https://github.com/user-attachments/assets/da11e665-5331-40ba-9f30-421c0f829b6d" />
